### PR TITLE
Add use case for "Create a data release"

### DIFF
--- a/objectives/create-data-release.md
+++ b/objectives/create-data-release.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Create Data Release
+nav_order: 3
+parent: Objectives
+has_children: false
+---
+
+Create a data release: The objective is to release a new or updated description of the
+data available from a single Common Fund Data Center.

--- a/personas/data-administrator.md
+++ b/personas/data-administrator.md
@@ -1,0 +1,24 @@
+---
+layout: default
+title: data-administrator
+nav_order: 1
+parent: Personas
+has_children: false
+---
+
+This user is a technical administrator of raw data, pipelines, portal, tools and/or processed data. They are supervised by a Data Custodian.
+
+### Data Administrator
+
+This user is charged with making sure their DCC's data is available, widely used, and used appropriately. 
+They have a deep knowledge of their DCC's dataset and the semantic meaning of each data component.
+Their computational knowledge ranges from intermediate to professional bioinformatician.
+
+### Assumptions
+
+Users with this persona:
+
+-   Are supervised by a Data Custodian
+-   Require some administrative access to an interface
+-   Use the CFDE Data Ingest tool
+-   Have intermediate to comprehensive bioinformatics expertise

--- a/requirements/r00001-the-interface-will-support-gui-web-access-to-end-users.md
+++ b/requirements/r00001-the-interface-will-support-gui-web-access-to-end-users.md
@@ -19,3 +19,5 @@ has_children: false
 -   [UC0001 Researcher Browse and Filter](../use-cases/browse-and-filter.md)
 -   [UC0002 NIH Compare across DCCs](../use-cases/multi-compare-custodian.md)
 -   [UC0003 Summary Statistics](../use-cases/summary-statistics.md)
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)
+

--- a/requirements/r00002-the-interface-will-support-user-authentication.md
+++ b/requirements/r00002-the-interface-will-support-user-authentication.md
@@ -18,3 +18,5 @@ has_children: false
 
 -   [UC0002 NIH Compare across DCCs](../use-cases/multi-compare-custodian.md)
 -   [UC0003 Summary Statistics](../use-cases/summary-statistics.md)
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)
+

--- a/requirements/r00004-the-c2m2-model-will-support-information-relating-uberon-terms-to-cf-programs.md
+++ b/requirements/r00004-the-c2m2-model-will-support-information-relating-uberon-terms-to-cf-programs.md
@@ -13,8 +13,12 @@ has_children: false
 
 -   [T0006 Search/filter data sets by anatomic terms](../user-tasks/t0006-searchfilter-data-sets-by-anatomic-terms.md)
 -   [T0011 Search/filter CF Programs by anatomic terms](../user-tasks/t0011-searchfilter-common-fund-programs-by-anatomic-terms.md)
+-   [T0013 Review C2M2 documentation](../user-tasks/t0013-review-c2m2-documentation.md)
+
 
 ## Use Cases
 
 -   [UC0001 Researcher Browse and Filter](../use-cases/browse-and-filter.md)
 -   [UC0002 NIH Compare across DCCs](../use-cases/multi-compare-custodian.md)
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)
+

--- a/requirements/r00007-the-c2m2-model-will-support-information-relating-assay-types-to-cf-programs.md
+++ b/requirements/r00007-the-c2m2-model-will-support-information-relating-assay-types-to-cf-programs.md
@@ -13,6 +13,7 @@ has_children: false
 
 -   [T0005 Search/filter data sets by type terms](../user-tasks/searchfilter-data-sets-by-type-terms.md)
 -   [T0007 Summarize all datatypes hosted by CF Program X](../user-tasks/t0007-summarize-all-datatypes-hosted-by-cf-program-x.md)
+-   [T0013 Review C2M2 documentation](../user-tasks/t0013-review-c2m2-documentation.md)
 
 
 ## Use Cases
@@ -20,3 +21,5 @@ has_children: false
 -   [UC0001 Researcher Browse and Filter](../use-cases/browse-and-filter.md)
 -   [UC0002 NIH Compare across DCCs](../use-cases/multi-compare-custodian.md)
 -   [UC0003 Summary Statistics](../use-cases/summary-statistics.md)
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)
+

--- a/requirements/r00011-the-c2m2-model-will-support-information-relating-projects-to-cf-programs.md
+++ b/requirements/r00011-the-c2m2-model-will-support-information-relating-projects-to-cf-programs.md
@@ -12,6 +12,7 @@ has_children: false
 ## User Tasks
 
 -   [T0005 Search/filter data sets by type terms](../user-tasks/searchfilter-data-sets-by-type-terms.md)
+-   [T0013 Review C2M2 documentation](../user-tasks/t0013-review-c2m2-documentation.md)
 
 
 ## Use Cases
@@ -19,3 +20,5 @@ has_children: false
 -   [UC0001 Researcher Browse and Filter](../use-cases/browse-and-filter.md)
 -   [UC0002 NIH Compare across DCCs](../use-cases/multi-compare-custodian.md)
 -   [UC0003 Summary Statistics](../use-cases/summary-statistics.md)
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)
+

--- a/requirements/r00016-the-c2m2-model-will-support-information-relating-species-terms-to-cf-programs.md
+++ b/requirements/r00016-the-c2m2-model-will-support-information-relating-species-terms-to-cf-programs.md
@@ -12,7 +12,10 @@ has_children: false
 ## User Tasks
 
 -   [T0011 Search/filter CF Programs by phenotypic terms](../user-tasks/t0011-searchfilter-common-fund-programs-by-phenotypic-terms.md)
+-   [T0013 Review C2M2 documentation](../user-tasks/t0013-review-c2m2-documentation.md)
+
 
 ## Use Cases
 
 -   [UC0002 NIH Compare across DCCs](../use-cases/multi-compare-custodian.md)
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)

--- a/requirements/r00019-the-c2m2-model-will-support-information-relating-fair-metrics-to-cf-programs.md
+++ b/requirements/r00019-the-c2m2-model-will-support-information-relating-fair-metrics-to-cf-programs.md
@@ -13,7 +13,9 @@ has_children: false
 
 -   [T0009 Summarize FAIRness scores by CF Program X](../user-tasks/t0009-summarize-fairness-scores-by-cf-program-x.md)
 -   [T0008 Summarize FAIRness scores by CF Program X over time](../user-tasks/t0008-summarize-fairness-scores-by-cf-program-x-over-time.md)
+-   [T0013 Review C2M2 documentation](../user-tasks/t0013-review-c2m2-documentation.md)
 
 ## Use Cases
 
 -   [UC0003 Summary Statistics](../use-cases/summary-statistics.md)
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)

--- a/requirements/r00022-the-c2m2-documentation-is-publicly-available.md
+++ b/requirements/r00022-the-c2m2-documentation-is-publicly-available.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: R00022 The C2M2 documentation is publicly available using a standard web browser and internet connection
+nav_order: 3
+parent: Requirements
+has_children: false
+---
+
+# Appears in:
+
+
+## User Tasks
+
+-   [T0013 Review C2M2 documentation](../user-tasks/t0013-review-c2m2-documentation.md)
+
+## Use Cases
+
+-   [Create a Data Release](../use-cases/create-data-release.md)

--- a/requirements/r00022-the-c2m2-documentation-is-publicly-available.md
+++ b/requirements/r00022-the-c2m2-documentation-is-publicly-available.md
@@ -15,4 +15,4 @@ has_children: false
 
 ## Use Cases
 
--   [Create a Data Release](../use-cases/create-data-release.md)
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)

--- a/requirements/r00023-the-cfde-ingest-tool-is-publicly-available.md
+++ b/requirements/r00023-the-cfde-ingest-tool-is-publicly-available.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: R00023 The CFDE ingest tool is publicly available
+nav_order: 3
+parent: Requirements
+has_children: false
+---
+
+# Appears in:
+
+
+## User Tasks
+
+-   [T0014 Install the CFDE ingest tool](../user-tasks/t0014-install-cfde-ingest-tool.md)
+
+## Use Cases
+
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)

--- a/requirements/r00024-the-cfde-ingest-tool-can-be-installed.md
+++ b/requirements/r00024-the-cfde-ingest-tool-can-be-installed.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: R00024 The CFDE ingest tool can be installed on a standard Mac, Windows, or Linux workstation or Linux server system
+nav_order: 3
+parent: Requirements
+has_children: false
+---
+
+# Appears in:
+
+
+## User Tasks
+
+-   [T0014 Install the CFDE ingest tool](../user-tasks/t0014-install-cfde-ingest-tool.md)
+
+## Use Cases
+
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)

--- a/requirements/r00025-the-cfde-ingest-tool-supports-user-authentication.md
+++ b/requirements/r00025-the-cfde-ingest-tool-supports-user-authentication.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: R00025 The CFDE ingest tool supports user authentication
+nav_order: 3
+parent: Requirements
+has_children: false
+---
+
+# Appears in:
+
+
+## User Tasks
+
+-   [T0015 Ingest a candidate data release](../user-tasks/t0015-ingest-candidate-data-release.md)
+
+## Use Cases
+
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)

--- a/requirements/r00026-the-cfde-ingest-tool-requires-authorization.md
+++ b/requirements/r00026-the-cfde-ingest-tool-requires-authorization.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: R00026 The CFDE ingest tool requires authorization to ingest data for a specific DCC
+nav_order: 3
+parent: Requirements
+has_children: false
+---
+
+# Appears in:
+
+
+## User Tasks
+
+-   [T0015 Ingest a candidate data release](../user-tasks/t0015-ingest-candidate-data-release.md)
+
+## Use Cases
+
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)

--- a/requirements/r00027-the-cfde-ingest-tool-can-ingest-data-in-the-c2m2-data-model.md
+++ b/requirements/r00027-the-cfde-ingest-tool-can-ingest-data-in-the-c2m2-data-model.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: R00027 The CFDE ingest tool can ingest data in the C2M2 data model
+nav_order: 3
+parent: Requirements
+has_children: false
+---
+
+# Appears in:
+
+
+## User Tasks
+
+-   [T0015 Ingest a candidate data release](../user-tasks/t0015-ingest-candidate-data-release.md)
+
+## Use Cases
+
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)

--- a/requirements/r00028-the-cfde-ingest-tool-rejects-malformed-c2m2-metadata.md
+++ b/requirements/r00028-the-cfde-ingest-tool-rejects-malformed-c2m2-metadata.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: R00028 The CFDE ingest tool rejects malformed C2M2 metadata and provides comprehensible/actionable diagnostics
+nav_order: 3
+parent: Requirements
+has_children: false
+---
+
+# Appears in:
+
+
+## User Tasks
+
+-   [T0015 Ingest a candidate data release](../user-tasks/t0015-ingest-candidate-data-release.md)
+
+## Use Cases
+
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)

--- a/requirements/r00029-the-interface-allows-data-administrators-to-review-the-ingest-results.md
+++ b/requirements/r00029-the-interface-allows-data-administrators-to-review-the-ingest-results.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: R00029 The interface allows data administrators to review the ingest results for their recent candidate data releases
+nav_order: 3
+parent: Requirements
+has_children: false
+---
+
+# Appears in:
+
+
+## User Tasks
+
+-   [T0016 Review and approve/reject ingest results of a candidate data release](../user-tasks/t0016-dcc-review-approve-reject-ingest-results.md)
+
+## Use Cases
+
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)

--- a/requirements/r00030-the-interface-allows-data-administrators-to-approve-a-recent-candidate-data-release.md
+++ b/requirements/r00030-the-interface-allows-data-administrators-to-approve-a-recent-candidate-data-release.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: R00030 The interface allows data administrators to approve a recent candidate data release
+nav_order: 3
+parent: Requirements
+has_children: false
+---
+
+# Appears in:
+
+
+## User Tasks
+
+-   [T0016 Review and approve/reject ingest results of a candidate data release](../user-tasks/t0016-dcc-review-approve-reject-ingest-results.md)
+
+## Use Cases
+
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)

--- a/requirements/r00031-when-data-release-is-approved-by-data-administrator-it-is-marked-for-review-by-cfde.md
+++ b/requirements/r00031-when-data-release-is-approved-by-data-administrator-it-is-marked-for-review-by-cfde.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: R00031 When a recent candidate data release is approved by the data administrator, the candidate data release is marked for review by CFDE personnel
+nav_order: 3
+parent: Requirements
+has_children: false
+---
+
+# Appears in:
+
+
+## User Tasks
+
+-   [T0016 Review and approve/reject ingest results of a candidate data release](../user-tasks/t0016-dcc-review-approve-reject-ingest-results.md)
+
+## Use Cases
+
+-   [UC0004 Create a Data Release](../use-cases/create-data-release.md)

--- a/use-cases/create-data-release.md
+++ b/use-cases/create-data-release.md
@@ -1,0 +1,75 @@
+---
+layout: default
+title: Summary Statistics
+nav_order: 3
+parent: Use Cases
+has_children: true
+---
+# Use Case UC0004 Create a Data Release
+
+**Persona:** [Data Administrator](../personas/data-administrator).
+
+**Objective:** [Create a Data Release](../objectives/create-data-release)
+
+# Summary
+
+Jordan is a Data Administrator for a Common Fund Data Coordinating Center. She needs 
+to provide a description of the Data Coordinating Center’s data to the CFDE so that: 
+(a) the data can be discovered by clinical researchers, (b) the data can be compared 
+with data from other Data Coordinating Centers, and (c) she and others can see how 
+CFDE’s metrics, statistics, and FAIRness measurements apply to the data. We assume 
+Jordan has previously been registered with CFDE and authorized by her Data 
+Coordinating Center to act as a data administrator on its behalf.
+
+Jordan first reviews the documentation for the C2M2 data model. If she has not 
+previously installed CFDE’s ingest tool, she does so. She then extracts the required 
+metadata from her Data Coordinating Center’s data and transforms it into the C2M2 
+data model. Once the metadata is in the C2M2 model, she runs CFDE’s ingest tool to 
+ingest the metadata. When the ingest completes, Jordan accesses the CFDE interface 
+and views the results in a non-public reviewing view. If the results are not 
+satisfactory, she adjusts the metadata and re-runs the ingest tool, repeating until 
+the results are satisfactory. If the results are satisfactory, she approves the data 
+release and it is marked for review by CFDE personnel. 
+
+
+### User Tasks
+
+-   [T0013 Review C2M2 documentation](../user-tasks/t0013-review-c2m2-documentation.md)
+-   [T0014 Install the CFDE ingest tool](../user-tasks/t0014-install-cfde-ingest-tool.md)
+-   [T0015 Ingest a candidate data release](../user-tasks/t0015-ingest-candidate-data-release.md)
+-   [T0001 Access to CFDE interface](../user-tasks/t0001-access-cfde-interface.md)
+-   [T0016 Review and approve/reject ingest results of a candidate data release](../user-tasks/t0016-dcc-review-approve-reject-ingest-results.md)
+
+### Requirements
+
+#### T0013 Review C2M2 documentation
+
+-   [R00004 The C2M2 model will support information relating Uberon terms to CF programs](../requirements/r00004-the-c2m2-model-will-support-information-relating-uberon-terms-to-cf-programs.md)
+-   [R00007 The C2M2 model will support information relating assay types to CF programs](../requirements/r00007-the-c2m2-model-will-support-information-relating-assay-types-to-cf-programs.md)
+-   [R00011 The C2M2 model will support information relating projects to CF programs](../requirements/r00011-the-c2m2-model-will-support-information-relating-projects-to-cf-programs.md)
+-   [R00016 The C2M2 model will support information relating species terms to CF programs](../requirements/r00016-the-c2m2-model-will-support-information-relating-species-terms-to-cf-programs.md)
+-   [R00019 The C2M2 model will support information relating FAIR metrics to CF programs](../requirements/r00019-the-c2m2-model-will-support-information-relating-fair-metrics-to-cf-programs.md)
+-   [R00022 The C2M2 documentation is publicly available using a standard web browser and internet connection](../requirements/r00022-the-c2m2-documentation-is-publicly-available.md)
+
+#### T0014 Install CFDE ingest tool
+
+-   [R00023 The CFDE ingest tool is publicly available](../requirements/r00023-the-cfde-ingest-tool-is-publicly-available.md)
+-   [R00024 The CFDE ingest tool can be installed on a standard Mac, Windows, or Linux workstation or Linux server system](../requirements/r00024-the-cfde-ingest-tool-can-be-installed.md)
+
+#### T0015 Ingest a candidate data release
+
+-   [R00025 The CFDE ingest tool supports user authentication](../requirements/r00025-the-cfde-ingest-tool-supports-user-authentication.md)
+-   [R00026 The CFDE ingest tool requires authorization to ingest data for a specific DCC](../requirements/r00026-the-cfde-ingest-tool-requires-authorization.md)
+-   [R00027 The CFDE ingest tool can ingest data in the C2M2 data model](../requirements/r00027-the-cfde-ingest-tool-can-ingest-data-in-the-c2m2-data-model.md)
+-   [R00028 The CFDE ingest tool rejects malformed C2M2 metadata and provides comprehensible/actionable diagnostics](../requirements/r00028-the-cfde-ingest-tool-rejects-malformed-c2m2-metadata.md)
+
+#### T0001 Access CFDE interface
+
+-   [R00001 The interface will support GUI web access to end users](../requirements/r00001-the-interface-will-support-gui-web-access-to-end-users.md)
+-   [R00002 The interface will support user authentication](../requirements/r00002-the-interface-will-support-user-authentication.md)
+
+#### T0016 Review and approve/reject ingest results of a candidate data release
+
+-   [R00029 The interface allows data administrators to review the ingest results for their recent candidate data releases](../requirements/r00029-the-interface-allows-data-administrators-to-review-the-ingest-results.md)
+-   [R00030 The interface allows data administrators to approve a recent candidate data release](../requirements/r00030-the-interface-allows-data-administrators-to-approve-a-recent-candidate-data-release.md)
+-   [R00031 When a recent candidate data release is approved by the data administrator, the candidate data release is marked for review by CFDE personnel](../requirements/r00031-when-data-release-is-approved-by-data-administrator-it-is-marked-for-review-by-cfde.md)

--- a/use-cases/create-data-release.md
+++ b/use-cases/create-data-release.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Summary Statistics
+title: Create a Data Release
 nav_order: 3
 parent: Use Cases
 has_children: true

--- a/user-tasks/t0001-access-cfde-interface.md
+++ b/user-tasks/t0001-access-cfde-interface.md
@@ -11,3 +11,4 @@ has_children: false
 -   [Researcher Browse and Filter](../use-cases/browse-and-filter.md)
 -   [NIH Compare across DCCs](../use-cases/multi-compare-custodian.md)
 -   [Summary Statistics](../use-cases/summary-statistics.md)
+-   [Create a Data Release](../use-cases/create-data-release.md)

--- a/user-tasks/t0013-review-c2m2-documentation.md
+++ b/user-tasks/t0013-review-c2m2-documentation.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: T0013 Review C2M2 documentation
+nav_order: 3
+parent: User Tasks
+has_children: false
+---
+
+## Appears in Use Cases:
+
+-   [Create a Data Release](../use-cases/create-data-release.md)

--- a/user-tasks/t0014-install-cfde-ingest-tool.md
+++ b/user-tasks/t0014-install-cfde-ingest-tool.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: T0014 Install the CFDE ingest tool
+nav_order: 3
+parent: User Tasks
+has_children: false
+---
+
+## Appears in Use Cases:
+
+-   [Create a Data Release](../use-cases/create-data-release.md)

--- a/user-tasks/t0015-ingest-candidate-data-release.md
+++ b/user-tasks/t0015-ingest-candidate-data-release.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: T0015 Ingest a candidate data release
+nav_order: 3
+parent: User Tasks
+has_children: false
+---
+
+## Appears in Use Cases:
+
+-   [Create a Data Release](../use-cases/create-data-release.md)

--- a/user-tasks/t0016-dcc-review-approve-reject-ingest-results.md
+++ b/user-tasks/t0016-dcc-review-approve-reject-ingest-results.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: T0016 Review and approve/reject ingest results of a candidate data release
+nav_order: 3
+parent: User Tasks
+has_children: false
+---
+
+## Appears in Use Cases:
+
+-   [Create a Data Release](../use-cases/create-data-release.md)


### PR DESCRIPTION
The new use case is from the perspective of a DCC technical staff member ("data administrator") who needs to generate a new data release that provides descriptive metadata for their DCC's data holdings so it becomes discoverable & comparable via the CFDE interface.