### PR TITLE
Making a style guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/usecase_suggestion_template.md
+++ b/.github/ISSUE_TEMPLATE/usecase_suggestion_template.md
@@ -1,2 +1,13 @@
-Describe your idea for a new use case here! Please include details about the required components: use case, persona, objective, user tasks, and requirements.
+---
+layout: default
+name: NewUseCase
+about: Submitting new use case idea as an issue
+title: Add use case idea title
+labels:
+assignees:
+---
 
+
+Short description of use case: Describe your idea for a new use case here! Please include details about the required components: use case, persona, objective, user tasks, and requirements.
+
+[sug, sug] <- comma-separated list of first 3 letters of desired tag

--- a/.github/ISSUE_TEMPLATE/usecase_suggestion_template.md
+++ b/.github/ISSUE_TEMPLATE/usecase_suggestion_template.md
@@ -1,0 +1,2 @@
+Describe your idea for a new use case here! Please include details about the required components: use case, persona, objective, user tasks, and requirements.
+

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,6 @@
+
+Please enter a short but specific title for the pull request.
+
+Please provide a short description of the changes you're requesting.
+
+Request review from @Acharbonneau and @marisalim

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -7,59 +7,147 @@ nav_order: 2
 
 # Contributing to the nih-cfde Use Case Repository
 
-Hello, and thank you for wanting to contribute to the CFDE Use Case
-Repository\!
+Hello, and thank you for your interest in contributing to the CFDE Use Case Repository!
 
 By contributing to this repository, you agree:
 
 1.  To obey the [Code of Conduct](./CODEOFCONDUCT.md)
-2.  To release all your contributions under the same terms as the
-    license itself: the [Creative Commons Zero](./LICENSE.md) (aka
-    Public Domain) license
+2.  To release all your contributions under the same terms as the license itself: the [Creative Commons Zero](./LICENSE.md) (aka Public Domain) license
 
-If you are OK with these two conditions, then we welcome both you and
-your contribution\!
+If you are OK with these two conditions, then we welcome both you and your contribution!
 
 ## How to add content
 
-If you have a suggestion for a new use case concept and are not familiar with GitHub,
-you can [email it to us](mailto:autohelp+int+851+6545985337373134556@CFDE.groups.io) 
+If you have a suggestion for a new use case concept and are not familiar with GitHub, you can [email your idea to us](mailto:autohelp+int+851+6545985337373134556@CFDE.groups.io).
 
 If you are familiar with GitHub please either:
- - [open an issue](https://github.com/nih-cfde/usecases/issues/new) describing your idea
- - or write up your Use Case and submit it as a pull request at [https://github.com/nih-cfde/usecases](https://github.com/nih-cfde/usecases)
-
-## Use Case Style Guide
-
-## Style Guide
-  
-### Use Case Structure
-  - All Use Cases must have...
-  - See glossary for details
-  
-### General File Format
-  - All files should be written in Markdown (link to markdown help)
-  - The site index is automatically created by yaml headers in each file. The yaml header must include...
-  - File names should be lower case, have hyphens, match the heading, etc
-
-#### Use Case files
-  - Need to have these sections...
-  - links should...
-  
-#### Requirements files
-  - Need to have these sections...
-  - links should...
-
-#### XXXX files...
-
+  - [open an issue](https://github.com/nih-cfde/usecases/issues/new) describing your idea
+  - or write up your use case and submit it as a pull request (PR) at [https://github.com/nih-cfde/usecases](https://github.com/nih-cfde/usecases). Please follow the [Use Case Style Guide](#usecasestyle) below.
 
 ### PR format
-  - Please create one pull request per Use Case so admin can check the complete change
-  - Request review from @Acharbonneau and @marisalim
-  - Please allow up to one week for admin to review your request
+If you are submitting a pull request:
+- Please create one pull request per use case so admin can check the complete change
+- Request review from @Acharbonneau and @marisalim
+- Please allow up to one week for admin to review your request
 
-If you have any questions about contributing, please [open an
-issue](https://github.com/nih-cfde/usecases/issues/new) and we
-will lend a hand ASAP.
+### Use Case approval process
+  - The Use Case committee will mark proposed use cases as `in progress`, `approved`, and `done`, as appropriate.
+  - If the Use Case has been approved, a &#x2705;will be added next to the Use Case tab title, as well as its corresponding Requirements tab titles.
+
+If you have any questions about contributing, please [open an issue](https://github.com/nih-cfde/usecases/issues/new) and we will lend a hand ASAP.
 
 Thank you for being here and for being a part of the CFDE project.
+
+## Use Case Repository Style Guide <a name="usecasestyle"></a>
+
+### Use Case Structure
+- All Use Cases must have:
+  - a **Persona**
+  - an **Objective**
+  - a **Summary** of the Objective
+  - specific **User Tasks**
+  - technical infrastructure **Requirements** for each User Task
+- See [glossary](./glossary.md) for definitions
+- Each persona, objective, user task, and requirement needs its own description page that will be linked to in the corresponding use case page(s) (some common user tasks and requirements may be repeated across use cases).
+
+
+### General File Format
+
+  **TO DO: make template file for use case pg?**
+
+- **File format**: all files should be written in Markdown
+  - **TO DO: add markdown help link**
+  - To add links to other pages:
+    ```
+    [<text to click on>](<link to file>)
+    ```
+    This is an example for a link to the Personas description page for 'Clinical Researcher':
+    ```
+    [Clinical Researcher](../personas/clinical-researcher.md)
+    ```
+- **Site index**: automatically created by yaml headers in each file (only the title is visible on the rendered website). The yaml header must be formatted as follows:
+  ```
+  ---
+  layout: default
+  title: "<Use case title>"
+  nav_order: <page number>
+  parent: Use Cases
+  completed: <month year>
+  has_children: false
+  ---
+  ```
+  This is an example for the 'UC0001' Use Case:
+  ```
+  ---
+  layout: default
+  title: "UC0001 Researcher Browse and Filter"
+  nav_order: 1
+  parent: Use Cases
+  completed: June 2020
+  has_children: false
+  ---
+  ```
+- **File names**: should be lower case, have hyphens, and match the heading. Use Case (`ucXXXX`), User Task (`tXXXX`), and Requirement (`rXXXXX`) files should include a file code numbered in order of appearance in this Use Case Library website.
+
+    File type | Example
+    --- | ---
+    use case | uc0001-researcher-browse-and-filter.md
+    persona | clinical-researcher.md
+    objective | create-data-release.md
+    user task | t0001-access-cfde-interface.md
+    requirement | r00001-the-interface-will-support-gui-web-access-to-end-users.md
+
+#### `Use Case` files
+- Required sections:
+  - yaml index header
+  - Page header: title, date completed (`<month> <year>`), persona, objective
+  ```
+  <Title>
+  Completed:
+  Persona:
+  Objective:
+  ```
+  - `Summary`: a short summary of the use case
+  - `User Tasks`: a bullet point list of the tasks required for the use case, including links to each task page. Tasks are numbered by `TXXXX`.
+  - `Requirements`: a bullet point list of the requirements for each task, including links to each requirement page. Requirements are numbered by `RXXXXX`.
+- The persona, objective, user tasks, and requirements need to be linked to their corresponding description page (detailed in the following sections)
+
+#### `Persona` files
+- Required sections:
+  - yaml index header
+  - Short description of their biological/computational experience and relation to any of the other Personas in the Use Cases Repository
+  - Persona title (same as yaml index title)
+  - Short description of the type of work they do, slightly more detailed than the first description
+  - A section listing assumptions about the persona's credentials e.g., access to the CFDE, formatted as follows:
+  ```
+  Assumptions
+        Users with this persona:
+  ```
+
+#### `Objective` files
+- Required sections:
+  - yaml index header
+  - `<name of the task>:`: brief ~1 sentence description of the task
+
+#### `User task` files
+- Required sections:
+  - yaml index header
+  - `Appears in Use Cases:`: bullet point list of the use case(s) that the task appears in, with page link to the use case page(s)
+
+**TO DO: will this page eventually include a description of the task?**
+
+#### `Requirement` files
+- Required sections:
+  - yaml index header
+  - Requirement title (same as yaml index title)
+  - An `Appears in` section with two sub-sections:
+  ```
+  Appears in:
+      User Tasks
+
+      Use Cases
+  ```
+    - Under `User Tasks`: bullet point list of the task(s) that the requirement appears in, with page link to the user task page
+    - Under `Use Cases`: bullet point list of the use case(s) that the requirement appears in, with page link to the use case page(s)
+
+**TO DO: will this page eventually include a description of the requirement?**

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -76,27 +76,45 @@ Thank you for being here and for being a part of the CFDE project.
 - **Site index**: automatically created by yaml headers in each file (only the title is visible on the rendered website). The yaml header must be formatted as follows:
 
   ```
+  
   ---
+  
   layout: default
+  
   title: "<Use case title>"
+  
   nav_order: <page number>
+  
   parent: <website tab name>
+  
   completed: <month year>
+  
   has_children: false
+  
   ---
+  
   ```
   
   This is an example for the 'UC0001' Use Case:
   
   ```
+  
   ---
+  
   layout: default
+  
   title: "UC0001 Researcher Browse and Filter"
+  
   nav_order: 1
+  
   parent: Use Cases
+  
   completed: June 2020
+  
   has_children: false
+  
   ---
+  
   ```
   
   The `parent` value depends on the Use Case file type:
@@ -123,12 +141,19 @@ Thank you for being here and for being a part of the CFDE project.
 - Required sections:
     - yaml index header
     - Page header: title, date completed (`<month> <year>`), persona, objective
+    
     ```
+    
     <Title>
+    
     Completed:
+    
     Persona:
+    
     Objective:
+    
     ```
+    
     - `Summary`: a short summary of the use case
     - `User Tasks`: a bullet point list of the tasks required for the use case, including links to each task page. Tasks are numbered by `TXXXX`.
     - `Requirements`: a bullet point list of the requirements for each task, including links to each requirement page. Requirements are numbered by `RXXXXX`.
@@ -143,8 +168,11 @@ Thank you for being here and for being a part of the CFDE project.
     - A section listing assumptions about the persona's credentials e.g., access to the CFDE, formatted as follows:
     
     ```
+    
     Assumptions
+    
           Users with this persona:
+          
     ```
 
 #### `Objective` files
@@ -164,10 +192,13 @@ Thank you for being here and for being a part of the CFDE project.
     - An `Appears in` section with two sub-sections:
   
     ```
+    
     Appears in:
+    
         User Tasks
 
         Use Cases
+        
     ```
   
       - Under `User Tasks`: bullet point list of the task(s) that the requirement appears in, with page link to the user task page

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -60,7 +60,7 @@ Thank you for being here and for being a part of the CFDE project!
 
 ### General File Format
 
-**File format** for all files should be written in Markdown.
+***File format** for all files should be written in Markdown.*
 
 - For help with Markdown syntax, see this [basic syntax guide](https://www.markdownguide.org/basic-syntax/)
 - To add links to other pages:
@@ -73,7 +73,7 @@ Thank you for being here and for being a part of the CFDE project!
 [Clinical Researcher](../personas/clinical-researcher.md)
 ```
     
-The **Site index** is automatically created by yaml headers in each file (only the title is visible on the rendered website). See [template files](https://github.com/nih-cfde/usecases/tree/StyleGuide/docs/template_files) for example structure.
+*The **Site index** is automatically created by yaml headers in each file (only the title is visible on the rendered website). See [template files](https://github.com/nih-cfde/usecases/tree/StyleGuide/docs/template_files) for example structure.*
 
   The `parent` yaml value depends on the website tab the Use Case file appears in:
   
@@ -85,7 +85,9 @@ The **Site index** is automatically created by yaml headers in each file (only t
   `User Tasks` | for user task files
   `Requirements` | for requirements files
   
-**File names** should be lower case, have hyphens, and match the heading. Use Case (`ucXXXX`), User Task (`tXXXX`), and Requirement (`rXXXXX`) files should include a file code numbered in order of appearance in this Use Case Repository website.
+  The Use Case committee will finalize yaml header page numbers to ensure they do not clash with existing files.
+  
+***File names** should be lower case, have hyphens, and match the heading. Use Case (`ucXXXX`), User Task (`tXXXX`), and Requirement (`rXXXXX`) files should include a file ID numbered in order of appearance in this Use Case Repository website.*
 
    File type | Example
    --- | ---
@@ -94,8 +96,10 @@ The **Site index** is automatically created by yaml headers in each file (only t
    objective | create-data-release.md
    user task | t0001-access-cfde-interface.md
    requirement | r00001-the-interface-will-support-gui-web-access-to-end-users.md
+   
+   The Use Case committee will finalize Use Case, User Task, and Requirement file IDs to ensure they do not clash with existing IDs.
 
-#### `Use Case` files
+### `Use Case` files
 - Use Case titles always begin with their `UCXXXX` ID
 - Required sections:
     - yaml index header
@@ -106,7 +110,7 @@ The **Site index** is automatically created by yaml headers in each file (only t
 - The persona, objective, user tasks, and requirements need to be linked to their corresponding description page (detailed in the following sections)
 - See [use case file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/use-case-template.md)
 
-#### `Persona` files
+### `Persona` files
 - Required sections:
     - yaml index header
     - Short description of their biological/computational experience and relation to any of the other Personas in the Use Cases Repository
@@ -115,13 +119,13 @@ The **Site index** is automatically created by yaml headers in each file (only t
     - A section listing assumptions about the persona's credentials e.g., access to the CFDE
 - See [persona file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/persona-template.md)
 
-#### `Objective` files
+### `Objective` files
 - Required sections:
     - yaml index header
     - `<name of the task>:`: brief ~1 sentence description of the task
 - See [objective file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/objective-template.md)
 
-#### `User task` files
+### `User task` files
 - The User Tasks title should be short and self-explanatory, but please add a short description as needed for clarity
 - User Task titles always begin with their `TXXXX` ID
 - Required sections:
@@ -129,7 +133,7 @@ The **Site index** is automatically created by yaml headers in each file (only t
     - `Appears in Use Cases:`: bullet point list of the use case(s) that the task appears in, with page link to the use case page(s)
 - See [user task file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/user-task-template.md)
 
-#### `Requirement` files
+### `Requirement` files
 - The Requirements title should be short and self-explanatory, but please add a short description as needed for clarity
 - Requirement titles always begin with their `RXXXXX` ID
 - Required sections:

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -56,11 +56,11 @@ Thank you for being here and for being a part of the CFDE project!
     - specific **User Tasks**
     - technical infrastructure **Requirements** for each User Task
 - See [glossary](./glossary.md) for definitions
-- Each persona, objective, user task, and requirement needs its own description page that will be linked to the corresponding use case page(s) (some common user tasks and requirements may be repeated across use cases).
+- Each persona, objective, user task, and requirement needs its own description page that will be linked to the corresponding use case page(s). Common user tasks and requirements should be reused across use cases.
 
 ### General File Format
 
-***File format** for all files should be written in Markdown.*
+**File format** for all files should be written in Markdown.
 
 - For help with Markdown syntax, see this [basic syntax guide](https://www.markdownguide.org/basic-syntax/)
 - To add links to other pages:
@@ -73,7 +73,7 @@ Thank you for being here and for being a part of the CFDE project!
 [Clinical Researcher](../personas/clinical-researcher.md)
 ```
     
-*The **Site index** is automatically created by yaml headers in each file (only the title is visible on the rendered website). See [template files](https://github.com/nih-cfde/usecases/tree/StyleGuide/docs/template_files) for example structure.*
+The **Site index** is automatically created by yaml headers in each file (only the title will be visible on the rendered website). See [template files](https://github.com/nih-cfde/usecases/tree/StyleGuide/docs/template_files) for example structure.
 
   The `parent` yaml value depends on the website tab the Use Case file appears in:
   
@@ -87,7 +87,7 @@ Thank you for being here and for being a part of the CFDE project!
   
   The Use Case committee will finalize yaml header page numbers to ensure they do not clash with existing files.
   
-***File names** should be lower case, have hyphens, and match the heading. Use Case (`ucXXXX`), User Task (`tXXXX`), and Requirement (`rXXXXX`) files should include a file ID numbered in order of appearance in this Use Case Repository website.*
+**File names** should be lower case, have hyphens, and match the heading. Use Case (`ucXXXX`), User Task (`tXXXX`), and Requirement (`rXXXXX`) files should include a file ID numbered in order of appearance in this Use Case Repository website.
 
    File type | Example
    --- | ---
@@ -113,7 +113,7 @@ Thank you for being here and for being a part of the CFDE project!
 ### `Persona` files
 - Required sections:
     - yaml index header
-    - Short description of their biological/computational experience and relation to any of the other Personas in the Use Cases Repository
+    - One line description of the biological/computational experience and relation to any of the other Personas in the Use Cases Repository
     - Persona title (same as yaml index title)
     - Short description of their work role and responsibilities, slightly more detailed than the first description
     - A section listing assumptions about the persona's credentials e.g., access to the CFDE

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -7,14 +7,6 @@ nav_order: 2
 
 # Contributing to the nih-cfde Use Case Repository
 
-
-```
-test code
-block
-does
-this render
-```
-
 Hello, and thank you for your interest in contributing to the CFDE Use Case Repository!
 
 By contributing to this repository, you agree:
@@ -71,44 +63,18 @@ Thank you for being here and for being a part of the CFDE project.
     - For help with Markdown syntax, see this [basic syntax guide](https://www.markdownguide.org/basic-syntax/)
   
     - To add links to other pages:
-  
     ```
     [<text to click on>](<link to file>)
     ```
     
     This is an example for a link to the Personas description page for 'Clinical Researcher':
-    
     ```
     [Clinical Researcher](../personas/clinical-researcher.md)
     ```
     
-- **Site index**: automatically created by yaml headers in each file (only the title is visible on the rendered website). The yaml header must be formatted as follows:
+- **Site index**: automatically created by yaml headers in each file (only the title is visible on the rendered website). See [template file](../template_files) for example structure.
 
-  ```
-  ---
-  layout: default
-  title: "<Use case title>"
-  nav_order: <page number>
-  parent: <website tab name>
-  completed: <month year>
-  has_children: false
-  ---
-  ```
-  
-  This is an example for the 'UC0001' Use Case:
-  
-  ```
-  ---
-  layout: default
-  title: "UC0001 Researcher Browse and Filter"
-  nav_order: 1
-  parent: Use Cases
-  completed: June 2020
-  has_children: false
-  ---
-  ```
-  
-  The `parent` value depends on the Use Case file type:
+  The `parent` yaml value depends on the website tab the Use Case file appears in:
   
   `parent:` value | Type
   --- | ---
@@ -129,21 +95,15 @@ Thank you for being here and for being a part of the CFDE project.
    requirement | r00001-the-interface-will-support-gui-web-access-to-end-users.md
 
 #### `Use Case` files
+- Use Case titles are always labeled with their `UCXXXX` ID
 - Required sections:
     - yaml index header
     - Page header: title, date completed (`<month> <year>`), persona, objective
-    
-    ```
-    <Title>
-    Completed:
-    Persona:
-    Objective:
-    ```
-    
     - `Summary`: a short summary of the use case
     - `User Tasks`: a bullet point list of the tasks required for the use case, including links to each task page. Tasks are numbered by `TXXXX`.
     - `Requirements`: a bullet point list of the requirements for each task, including links to each requirement page. Requirements are numbered by `RXXXXX`.
 - The persona, objective, user tasks, and requirements need to be linked to their corresponding description page (detailed in the following sections)
+- See [use case file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/use-case-template.md)
 
 #### `Persona` files
 - Required sections:
@@ -151,35 +111,28 @@ Thank you for being here and for being a part of the CFDE project.
     - Short description of their biological/computational experience and relation to any of the other Personas in the Use Cases Repository
     - Persona title (same as yaml index title)
     - Short description of the type of work they do, slightly more detailed than the first description
-    - A section listing assumptions about the persona's credentials e.g., access to the CFDE, formatted as follows:
-    
-    ```
-    Assumptions
-          Users with this persona:    
-    ```
+    - A section listing assumptions about the persona's credentials e.g., access to the CFDE
+- See [persona file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/persona-template.md)
 
 #### `Objective` files
 - Required sections:
     - yaml index header
     - `<name of the task>:`: brief ~1 sentence description of the task
+- See [objective file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/objective-template.md)
 
 #### `User task` files
+- User Task titles are always labeled with their `TXXXX` ID
 - Required sections:
     - yaml index header
     - `Appears in Use Cases:`: bullet point list of the use case(s) that the task appears in, with page link to the use case page(s)
+- See [user task file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/user-task-template.md)
 
 #### `Requirement` files
+- Requirement titles are always labeled with their `RXXXXX` ID
 - Required sections:
     - yaml index header
     - Requirement title (same as yaml index title)
     - An `Appears in` section with two sub-sections:
-  
-    ```
-    Appears in:
-        User Tasks
-        Use Cases
-    ```
-  
       - Under `User Tasks`: bullet point list of the task(s) that the requirement appears in, with page link to the user task page
       - Under `Use Cases`: bullet point list of the use case(s) that the requirement appears in, with page link to the use case page(s)
-
+- See [requirement file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/requirement-template.md)

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -27,18 +27,19 @@ If you are familiar with GitHub please either:
   - or write up your use case and submit it as a pull request (PR). Please follow the [Use Case Style Guide](#usecasestyle) below.
 
 ### PR format
-If you are submitting a pull request, please create one pull request per use case so admin can check the complete change. See [template]().
+If you are submitting a pull request, please create one pull request per use case so admin can check the complete change.
 
 PR process:
 
 **First, preview new changes**
+
   - Create a new branch in the [use cases repo](https://github.com/nih-cfde/usecases)
   - Use the [use case file templates](https://github.com/nih-cfde/usecases/tree/master/docs/template_files) to add your new use case files
   - Submit a PR from your branch to the `preview` branch. After you submit the PR, make sure the repo checks complete (green check mark).
   - If the checks complete successfully, merge the changes and view the [preview website](https://cfde-usecases.readthedocs-hosted.com/en/preview/) to check the changes. It can take ~30 minutes for the new changes to appear. If the checks failed, you can submit an issue for help.
 
 **Second, if you are satisfied with the changes, submit a new PR from your branch to the `master` branch.**
-  - See [template]()
+
   - Request review from @Acharbonneau and @marisalim
   - Please allow up to one week for admin to review your request
 

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -32,7 +32,7 @@ If you are submitting a pull request:
 
 ### Use Case approval process
   - The Use Case committee will mark proposed use cases as `in progress`, `approved`, and `done`, as appropriate.
-  - If the Use Case has been approved, a &#x2705;will be added next to the Use Case tab title, as well as its corresponding Requirements tab titles.
+  - If the Use Case has been approved, a &#x2705; will be added next to the Use Case tab title, as well as its corresponding Requirements tab titles.
 
 If you have any questions about contributing, please [open an issue](https://github.com/nih-cfde/usecases/issues/new) and we will lend a hand ASAP.
 
@@ -56,7 +56,7 @@ Thank you for being here and for being a part of the CFDE project.
   **TO DO: make template file for use case pg?**
 
 - **File format**: all files should be written in Markdown
-  - **TO DO: add markdown help link**
+  - For help with Markdown syntax, see this [basic syntax guide](https://www.markdownguide.org/basic-syntax/)
   - To add links to other pages:
     ```
     [<text to click on>](<link to file>)

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -71,7 +71,7 @@ Thank you for being here and for being a part of the CFDE project.
   layout: default
   title: "<Use case title>"
   nav_order: <page number>
-  parent: Use Cases
+  parent: <file directory name>
   completed: <month year>
   has_children: false
   ---
@@ -87,6 +87,15 @@ Thank you for being here and for being a part of the CFDE project.
   has_children: false
   ---
   ```
+  The `parent` value depends on the Use Case file type:
+  `parent:` value | Type
+  --- | ---
+  `Use Cases` | for the main Use Case file
+  `Personas` | for persona files
+  `Objectives` | for objective files
+  `User Tasks` | for user task files
+  `Requirements` | for requirements files
+  
 - **File names**: should be lower case, have hyphens, and match the heading. Use Case (`ucXXXX`), User Task (`tXXXX`), and Requirement (`rXXXXX`) files should include a file code numbered in order of appearance in this Use Case Library website.
 
     File type | Example

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -56,6 +56,7 @@ Thank you for being here and for being a part of the CFDE project!
 ### General File Format
 
 **File format** for all files should be written in Markdown.
+
 - For help with Markdown syntax, see this [basic syntax guide](https://www.markdownguide.org/basic-syntax/)
 - To add links to other pages:
     

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -30,19 +30,16 @@ If you are familiar with GitHub please either:
 If you are submitting a pull request:
 
 - Please create one pull request per use case so admin can check the complete change
-
 - Request review from @Acharbonneau and @marisalim
-
 - Please allow up to one week for admin to review your request
 
 ### Use Case approval process
 - The Use Case committee will mark proposed use cases as `in progress`, `approved`, and `done`, as appropriate.
-  
 - If the Use Case has been approved, a &#x2705; will be added next to the Use Case tab title, as well as its corresponding Requirements tab titles.
 
 If you have any questions about contributing, please [open an issue](https://github.com/nih-cfde/usecases/issues/new) and we will lend a hand ASAP.
 
-Thank you for being here and for being a part of the CFDE project.
+Thank you for being here and for being a part of the CFDE project!
 
 ## Use Case Repository Style Guide <a name="usecasestyle"></a>
 
@@ -58,23 +55,19 @@ Thank you for being here and for being a part of the CFDE project.
 
 ### General File Format
 
-- **File format**: all files should be written in Markdown
+**File format** for all files should be written in Markdown.
+- For help with Markdown syntax, see this [basic syntax guide](https://www.markdownguide.org/basic-syntax/)
+- To add links to other pages:
+    
+```
+# syntax
+[<text to click on>](<Github repo relative path to file>)
 
-    - For help with Markdown syntax, see this [basic syntax guide](https://www.markdownguide.org/basic-syntax/)
-  
-    - To add links to other pages:
+# This is an example for a link to the Personas description page for 'Clinical Researcher':
+[Clinical Researcher](../personas/clinical-researcher.md)
+```
     
-    ```
-    [<text to click on>](<link to file>)
-    ```
-    
-    This is an example for a link to the Personas description page for 'Clinical Researcher':
-    
-    ```
-    [Clinical Researcher](../personas/clinical-researcher.md)
-    ```
-    
-- **Site index**: automatically created by yaml headers in each file (only the title is visible on the rendered website). See [template file](https://github.com/nih-cfde/usecases/tree/StyleGuide/docs/template_files) for example structure.
+The **Site index** is automatically created by yaml headers in each file (only the title is visible on the rendered website). See [template files](https://github.com/nih-cfde/usecases/tree/StyleGuide/docs/template_files) for example structure.
 
   The `parent` yaml value depends on the website tab the Use Case file appears in:
   
@@ -86,7 +79,7 @@ Thank you for being here and for being a part of the CFDE project.
   `User Tasks` | for user task files
   `Requirements` | for requirements files
   
-- **File names**: should be lower case, have hyphens, and match the heading. Use Case (`ucXXXX`), User Task (`tXXXX`), and Requirement (`rXXXXX`) files should include a file code numbered in order of appearance in this Use Case Repository website.
+**File names** should be lower case, have hyphens, and match the heading. Use Case (`ucXXXX`), User Task (`tXXXX`), and Requirement (`rXXXXX`) files should include a file code numbered in order of appearance in this Use Case Repository website.
 
    File type | Example
    --- | ---

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -6,6 +6,15 @@ nav_order: 2
 ---
 
 # Contributing to the nih-cfde Use Case Repository
+
+
+```
+test code
+block
+does
+this render
+```
+
 Hello, and thank you for your interest in contributing to the CFDE Use Case Repository!
 
 By contributing to this repository, you agree:
@@ -76,45 +85,27 @@ Thank you for being here and for being a part of the CFDE project.
 - **Site index**: automatically created by yaml headers in each file (only the title is visible on the rendered website). The yaml header must be formatted as follows:
 
   ```
-  
   ---
-  
   layout: default
-  
   title: "<Use case title>"
-  
   nav_order: <page number>
-  
   parent: <website tab name>
-  
   completed: <month year>
-  
   has_children: false
-  
   ---
-  
   ```
   
   This is an example for the 'UC0001' Use Case:
   
   ```
-  
   ---
-  
   layout: default
-  
   title: "UC0001 Researcher Browse and Filter"
-  
   nav_order: 1
-  
   parent: Use Cases
-  
   completed: June 2020
-  
   has_children: false
-  
   ---
-  
   ```
   
   The `parent` value depends on the Use Case file type:
@@ -143,15 +134,10 @@ Thank you for being here and for being a part of the CFDE project.
     - Page header: title, date completed (`<month> <year>`), persona, objective
     
     ```
-    
     <Title>
-    
     Completed:
-    
     Persona:
-    
     Objective:
-    
     ```
     
     - `Summary`: a short summary of the use case
@@ -168,11 +154,8 @@ Thank you for being here and for being a part of the CFDE project.
     - A section listing assumptions about the persona's credentials e.g., access to the CFDE, formatted as follows:
     
     ```
-    
     Assumptions
-    
-          Users with this persona:
-          
+          Users with this persona:    
     ```
 
 #### `Objective` files
@@ -192,13 +175,9 @@ Thank you for being here and for being a part of the CFDE project.
     - An `Appears in` section with two sub-sections:
   
     ```
-    
     Appears in:
-    
         User Tasks
-
         Use Cases
-        
     ```
   
       - Under `User Tasks`: bullet point list of the task(s) that the requirement appears in, with page link to the user task page

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -20,6 +20,44 @@ By contributing to this repository, you agree:
 If you are OK with these two conditions, then we welcome both you and
 your contribution\!
 
+## How to add content
+
+If you have a suggestion for a new use case concept and are not familiar with GitHub,
+you can [email it to us](mailto:autohelp+int+851+6545985337373134556@CFDE.groups.io) 
+
+If you are familiar with GitHub please either:
+ - [open an issue](https://github.com/nih-cfde/usecases/issues/new) describing your idea
+ - or write up your Use Case and submit it as a pull request at [https://github.com/nih-cfde/usecases](https://github.com/nih-cfde/usecases)
+
+## Use Case Style Guide
+
+## Style Guide
+  
+### Use Case Structure
+  - All Use Cases must have...
+  - See glossary for details
+  
+### General File Format
+  - All files should be written in Markdown (link to markdown help)
+  - The site index is automatically created by yaml headers in each file. The yaml header must include...
+  - File names should be lower case, have hyphens, match the heading, etc
+
+#### Use Case files
+  - Need to have these sections...
+  - links should...
+  
+#### Requirements files
+  - Need to have these sections...
+  - links should...
+
+#### XXXX files...
+
+
+### PR format
+  - Please create one pull request per Use Case so admin can check the complete change
+  - Request review from @Acharbonneau and @marisalim
+  - Please allow up to one week for admin to review your request
+
 If you have any questions about contributing, please [open an
 issue](https://github.com/nih-cfde/usecases/issues/new) and we
 will lend a hand ASAP.

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -24,14 +24,24 @@ If you are familiar with GitHub please either:
 
   - [open an issue](https://github.com/nih-cfde/usecases/issues/new) describing your idea
   
-  - or write up your use case and submit it as a pull request (PR) at [https://github.com/nih-cfde/usecases](https://github.com/nih-cfde/usecases). Please follow the [Use Case Style Guide](#usecasestyle) below.
+  - or write up your use case and submit it as a pull request (PR). Please follow the [Use Case Style Guide](#usecasestyle) below.
 
 ### PR format
-If you are submitting a pull request:
+If you are submitting a pull request, please create one pull request per use case so admin can check the complete change. See [template]().
 
-- Please create one pull request per use case so admin can check the complete change
+PR process:
+
+1. Preview new changes
+- Create a new branch in the [use cases repo](https://github.com/nih-cfde/usecases)
+- Use the [use case file templates](../template_files) to add your new use case files
+- Submit a PR from your branch to the `preview` branch. After you submit the PR, make sure the repo checks complete (green check mark).
+- If the checks complete successfully, merge the changes and view the [preview website](https://cfde-usecases.readthedocs-hosted.com/en/preview/) to check the changes. It can take ~30 minutes for the new changes to appear. If the checks failed, you can submit an issue for help.
+
+2. If you are satisfied with the changes, submit a new PR from your branch to the `master` branch.
+- See [template]()
 - Request review from @Acharbonneau and @marisalim
 - Please allow up to one week for admin to review your request
+
 
 ### Use Case approval process
 - The Use Case committee will mark proposed use cases, and corresponding requirements pages, as `in progress`, `approved`, and `done`, as appropriate:
@@ -73,7 +83,7 @@ Thank you for being here and for being a part of the CFDE project!
 [Clinical Researcher](../personas/clinical-researcher.md)
 ```
     
-The **Site index** is automatically created by yaml headers in each file (only the title will be visible on the rendered website). See [template files](https://github.com/nih-cfde/usecases/tree/StyleGuide/docs/template_files) for example structure.
+The **Site index** is automatically created by yaml headers in each file (only the title will be visible on the rendered website). See [template files](../template_files) for example structure.
 
   The `parent` yaml value depends on the website tab the Use Case file appears in:
   
@@ -108,20 +118,23 @@ The **Site index** is automatically created by yaml headers in each file (only t
     - `User Tasks`: a bullet point list of the tasks required for the use case, including links to each task page. Tasks are numbered by `TXXXX`.
     - `Requirements`: a bullet point list of the requirements for each task, including links to each requirement page. Requirements are numbered by `RXXXXX`.
 - The persona, objective, user tasks, and requirements need to be linked to their corresponding description page (detailed in the following sections)
-- See [use case file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/use-case-template.md)
+- See [use case file template](../template_files/use-case-template.md)
+- Use case files should be saved [here](../use-cases/)
 
 ### `Persona` files
 - Required sections:
     - yaml index header
     - Short description of their biological/computational experience, their role and responsibilities, and relation to any of the other Personas in the Use Cases Repository
     - A section listing assumptions about the persona's credentials e.g., access to the CFDE
-- See [persona file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/persona-template.md)
+- See [persona file template](../template_files/persona-template.md)
+- Persona files should be saved [here](../personas/)
 
 ### `Objective` files
 - Required sections:
     - yaml index header
     - `<name of the task>:`: brief ~1 sentence description of the task
-- See [objective file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/objective-template.md)
+- See [objective file template](../template_files/objective-template.md)
+- Objective files should be saved [here](../objectives/)
 
 ### `User task` files
 - The User Tasks title should be short and self-explanatory, but please add a short description as needed for clarity
@@ -129,7 +142,8 @@ The **Site index** is automatically created by yaml headers in each file (only t
 - Required sections:
     - yaml index header
     - `Appears in Use Cases:`: bullet point list of the use case(s) that the task appears in, with page link to the use case page(s)
-- See [user task file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/user-task-template.md)
+- See [user task file template](../template_files/user-task-template.md)
+- User task files should be saved [here](../user-tasks/)
 
 ### `Requirement` files
 - The Requirements title should be short and self-explanatory, but please add a short description as needed for clarity
@@ -140,4 +154,5 @@ The **Site index** is automatically created by yaml headers in each file (only t
     - An `Appears in` section with two sub-sections:
       - Under `User Tasks`: bullet point list of the task(s) that the requirement appears in, with page link to the user task page
       - Under `Use Cases`: bullet point list of the use case(s) that the requirement appears in, with page link to the use case page(s)
-- See [requirement file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/requirement-template.md)
+- See [requirement file template](../template_files/requirement-template.md)
+- Requirements files should be saved [here](../requirements/)

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -31,15 +31,13 @@ If you are submitting a pull request, please create one pull request per use cas
 
 PR process:
 
-1. Preview new changes
-
+**First, preview new changes**
   - Create a new branch in the [use cases repo](https://github.com/nih-cfde/usecases)
   - Use the [use case file templates](https://github.com/nih-cfde/usecases/tree/master/docs/template_files) to add your new use case files
   - Submit a PR from your branch to the `preview` branch. After you submit the PR, make sure the repo checks complete (green check mark).
   - If the checks complete successfully, merge the changes and view the [preview website](https://cfde-usecases.readthedocs-hosted.com/en/preview/) to check the changes. It can take ~30 minutes for the new changes to appear. If the checks failed, you can submit an issue for help.
 
-2. If you are satisfied with the changes, submit a new PR from your branch to the `master` branch.
-
+**Second, if you are satisfied with the changes, submit a new PR from your branch to the `master` branch.**
   - See [template]()
   - Request review from @Acharbonneau and @marisalim
   - Please allow up to one week for admin to review your request

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -115,7 +115,7 @@ Thank you for being here and for being a part of the CFDE project!
     - yaml index header
     - Short description of their biological/computational experience and relation to any of the other Personas in the Use Cases Repository
     - Persona title (same as yaml index title)
-    - Short description of the type of work they do, slightly more detailed than the first description
+    - Short description of their work role and responsibilities, slightly more detailed than the first description
     - A section listing assumptions about the persona's credentials e.g., access to the CFDE
 - See [persona file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/persona-template.md)
 

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -54,7 +54,7 @@ Thank you for being here and for being a part of the CFDE project.
     - specific **User Tasks**
     - technical infrastructure **Requirements** for each User Task
 - See [glossary](./glossary.md) for definitions
-- Each persona, objective, user task, and requirement needs its own description page that will be linked to in the corresponding use case page(s) (some common user tasks and requirements may be repeated across use cases).
+- Each persona, objective, user task, and requirement needs its own description page that will be linked to the corresponding use case page(s) (some common user tasks and requirements may be repeated across use cases).
 
 ### General File Format
 
@@ -86,7 +86,7 @@ Thank you for being here and for being a part of the CFDE project.
   `User Tasks` | for user task files
   `Requirements` | for requirements files
   
-- **File names**: should be lower case, have hyphens, and match the heading. Use Case (`ucXXXX`), User Task (`tXXXX`), and Requirement (`rXXXXX`) files should include a file code numbered in order of appearance in this Use Case Library website.
+- **File names**: should be lower case, have hyphens, and match the heading. Use Case (`ucXXXX`), User Task (`tXXXX`), and Requirement (`rXXXXX`) files should include a file code numbered in order of appearance in this Use Case Repository website.
 
    File type | Example
    --- | ---
@@ -97,7 +97,7 @@ Thank you for being here and for being a part of the CFDE project.
    requirement | r00001-the-interface-will-support-gui-web-access-to-end-users.md
 
 #### `Use Case` files
-- Use Case titles are always labeled with their `UCXXXX` ID
+- Use Case titles always begin with their `UCXXXX` ID
 - Required sections:
     - yaml index header
     - Page header: title, date completed (`<month> <year>`), persona, objective
@@ -124,7 +124,7 @@ Thank you for being here and for being a part of the CFDE project.
 
 #### `User task` files
 - The User Tasks title should be short and self-explanatory, but please add a short description as needed for clarity
-- User Task titles are always labeled with their `TXXXX` ID
+- User Task titles always begin with their `TXXXX` ID
 - Required sections:
     - yaml index header
     - `Appears in Use Cases:`: bullet point list of the use case(s) that the task appears in, with page link to the use case page(s)
@@ -132,7 +132,7 @@ Thank you for being here and for being a part of the CFDE project.
 
 #### `Requirement` files
 - The Requirements title should be short and self-explanatory, but please add a short description as needed for clarity
-- Requirement titles are always labeled with their `RXXXXX` ID
+- Requirement titles always begin with their `RXXXXX` ID
 - Required sections:
     - yaml index header
     - Requirement title (same as yaml index title)

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -71,7 +71,7 @@ Thank you for being here and for being a part of the CFDE project.
   layout: default
   title: "<Use case title>"
   nav_order: <page number>
-  parent: <file directory name>
+  parent: <website tab name>
   completed: <month year>
   has_children: false
   ---

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -113,9 +113,7 @@ The **Site index** is automatically created by yaml headers in each file (only t
 ### `Persona` files
 - Required sections:
     - yaml index header
-    - One line description of the biological/computational experience and relation to any of the other Personas in the Use Cases Repository
-    - Persona title (same as yaml index title)
-    - Short description of their work role and responsibilities, slightly more detailed than the first description
+    - Short description of their biological/computational experience, their role and responsibilities, and relation to any of the other Personas in the Use Cases Repository
     - A section listing assumptions about the persona's credentials e.g., access to the CFDE
 - See [persona file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/persona-template.md)
 

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -63,16 +63,18 @@ Thank you for being here and for being a part of the CFDE project.
     - For help with Markdown syntax, see this [basic syntax guide](https://www.markdownguide.org/basic-syntax/)
   
     - To add links to other pages:
+    
     ```
     [<text to click on>](<link to file>)
     ```
     
     This is an example for a link to the Personas description page for 'Clinical Researcher':
+    
     ```
     [Clinical Researcher](../personas/clinical-researcher.md)
     ```
     
-- **Site index**: automatically created by yaml headers in each file (only the title is visible on the rendered website). See [template file](../template_files) for example structure.
+- **Site index**: automatically created by yaml headers in each file (only the title is visible on the rendered website). See [template file](https://github.com/nih-cfde/usecases/tree/StyleGuide/docs/template_files) for example structure.
 
   The `parent` yaml value depends on the website tab the Use Case file appears in:
   

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -34,8 +34,13 @@ If you are submitting a pull request:
 - Please allow up to one week for admin to review your request
 
 ### Use Case approval process
-- The Use Case committee will mark proposed use cases as `in progress`, `approved`, and `done`, as appropriate.
-- If the Use Case has been approved, a &#x2705; will be added next to the Use Case tab title, as well as its corresponding Requirements tab titles.
+- The Use Case committee will mark proposed use cases, and corresponding requirements pages, as `in progress`, `approved`, and `done`, as appropriate:
+
+Progress | Symbol
+--- | ---
+in progress | &#x23F3;
+approved | &#x1F44C;
+done | &#x2705;
 
 If you have any questions about contributing, please [open an issue](https://github.com/nih-cfde/usecases/issues/new) and we will lend a hand ASAP.
 

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -32,12 +32,14 @@ If you are submitting a pull request, please create one pull request per use cas
 PR process:
 
 1. Preview new changes
+
   - Create a new branch in the [use cases repo](https://github.com/nih-cfde/usecases)
   - Use the [use case file templates](https://github.com/nih-cfde/usecases/tree/master/docs/template_files) to add your new use case files
   - Submit a PR from your branch to the `preview` branch. After you submit the PR, make sure the repo checks complete (green check mark).
   - If the checks complete successfully, merge the changes and view the [preview website](https://cfde-usecases.readthedocs-hosted.com/en/preview/) to check the changes. It can take ~30 minutes for the new changes to appear. If the checks failed, you can submit an issue for help.
 
 2. If you are satisfied with the changes, submit a new PR from your branch to the `master` branch.
+
   - See [template]()
   - Request review from @Acharbonneau and @marisalim
   - Please allow up to one week for admin to review your request

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -123,6 +123,7 @@ Thank you for being here and for being a part of the CFDE project.
 - See [objective file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/objective-template.md)
 
 #### `User task` files
+- The User Tasks title should be short and self-explanatory, but please add a short description as needed for clarity
 - User Task titles are always labeled with their `TXXXX` ID
 - Required sections:
     - yaml index header
@@ -130,6 +131,7 @@ Thank you for being here and for being a part of the CFDE project.
 - See [user task file template](https://github.com/nih-cfde/usecases/blob/StyleGuide/docs/template_files/user-task-template.md)
 
 #### `Requirement` files
+- The Requirements title should be short and self-explanatory, but please add a short description as needed for clarity
 - Requirement titles are always labeled with their `RXXXXX` ID
 - Required sections:
     - yaml index header

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -32,15 +32,15 @@ If you are submitting a pull request, please create one pull request per use cas
 PR process:
 
 1. Preview new changes
-- Create a new branch in the [use cases repo](https://github.com/nih-cfde/usecases)
-- Use the [use case file templates](../template_files) to add your new use case files
-- Submit a PR from your branch to the `preview` branch. After you submit the PR, make sure the repo checks complete (green check mark).
-- If the checks complete successfully, merge the changes and view the [preview website](https://cfde-usecases.readthedocs-hosted.com/en/preview/) to check the changes. It can take ~30 minutes for the new changes to appear. If the checks failed, you can submit an issue for help.
+  - Create a new branch in the [use cases repo](https://github.com/nih-cfde/usecases)
+  - Use the [use case file templates](https://github.com/nih-cfde/usecases/tree/master/docs/template_files) to add your new use case files
+  - Submit a PR from your branch to the `preview` branch. After you submit the PR, make sure the repo checks complete (green check mark).
+  - If the checks complete successfully, merge the changes and view the [preview website](https://cfde-usecases.readthedocs-hosted.com/en/preview/) to check the changes. It can take ~30 minutes for the new changes to appear. If the checks failed, you can submit an issue for help.
 
 2. If you are satisfied with the changes, submit a new PR from your branch to the `master` branch.
-- See [template]()
-- Request review from @Acharbonneau and @marisalim
-- Please allow up to one week for admin to review your request
+  - See [template]()
+  - Request review from @Acharbonneau and @marisalim
+  - Please allow up to one week for admin to review your request
 
 
 ### Use Case approval process
@@ -83,7 +83,7 @@ Thank you for being here and for being a part of the CFDE project!
 [Clinical Researcher](../personas/clinical-researcher.md)
 ```
     
-The **Site index** is automatically created by yaml headers in each file (only the title will be visible on the rendered website). See [template files](../template_files) for example structure.
+The **Site index** is automatically created by yaml headers in each file (only the title will be visible on the rendered website). See [template files](https://github.com/nih-cfde/usecases/tree/master/docs/template_files) for example structure.
 
   The `parent` yaml value depends on the website tab the Use Case file appears in:
   
@@ -119,7 +119,7 @@ The **Site index** is automatically created by yaml headers in each file (only t
     - `Requirements`: a bullet point list of the requirements for each task, including links to each requirement page. Requirements are numbered by `RXXXXX`.
 - The persona, objective, user tasks, and requirements need to be linked to their corresponding description page (detailed in the following sections)
 - See [use case file template](../template_files/use-case-template.md)
-- Use case files should be saved [here](../use-cases/)
+- Use case files should be saved [here](https://github.com/nih-cfde/usecases/tree/master/docs/use-cases)
 
 ### `Persona` files
 - Required sections:
@@ -127,14 +127,14 @@ The **Site index** is automatically created by yaml headers in each file (only t
     - Short description of their biological/computational experience, their role and responsibilities, and relation to any of the other Personas in the Use Cases Repository
     - A section listing assumptions about the persona's credentials e.g., access to the CFDE
 - See [persona file template](../template_files/persona-template.md)
-- Persona files should be saved [here](../personas/)
+- Persona files should be saved [here](https://github.com/nih-cfde/usecases/tree/master/docs/personas/)
 
 ### `Objective` files
 - Required sections:
     - yaml index header
     - `<name of the task>:`: brief ~1 sentence description of the task
 - See [objective file template](../template_files/objective-template.md)
-- Objective files should be saved [here](../objectives/)
+- Objective files should be saved [here](https://github.com/nih-cfde/usecases/tree/master/docs/objectives/)
 
 ### `User task` files
 - The User Tasks title should be short and self-explanatory, but please add a short description as needed for clarity
@@ -143,7 +143,7 @@ The **Site index** is automatically created by yaml headers in each file (only t
     - yaml index header
     - `Appears in Use Cases:`: bullet point list of the use case(s) that the task appears in, with page link to the use case page(s)
 - See [user task file template](../template_files/user-task-template.md)
-- User task files should be saved [here](../user-tasks/)
+- User task files should be saved [here](https://github.com/nih-cfde/usecases/tree/master/docs/user-tasks/)
 
 ### `Requirement` files
 - The Requirements title should be short and self-explanatory, but please add a short description as needed for clarity
@@ -155,4 +155,4 @@ The **Site index** is automatically created by yaml headers in each file (only t
       - Under `User Tasks`: bullet point list of the task(s) that the requirement appears in, with page link to the user task page
       - Under `Use Cases`: bullet point list of the use case(s) that the requirement appears in, with page link to the use case page(s)
 - See [requirement file template](../template_files/requirement-template.md)
-- Requirements files should be saved [here](../requirements/)
+- Requirements files should be saved [here](https://github.com/nih-cfde/usecases/tree/master/docs/requirements/)

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -6,7 +6,6 @@ nav_order: 2
 ---
 
 # Contributing to the nih-cfde Use Case Repository
-
 Hello, and thank you for your interest in contributing to the CFDE Use Case Repository!
 
 By contributing to this repository, you agree:
@@ -21,18 +20,24 @@ If you are OK with these two conditions, then we welcome both you and your contr
 If you have a suggestion for a new use case concept and are not familiar with GitHub, you can [email your idea to us](mailto:autohelp+int+851+6545985337373134556@CFDE.groups.io).
 
 If you are familiar with GitHub please either:
+
   - [open an issue](https://github.com/nih-cfde/usecases/issues/new) describing your idea
+  
   - or write up your use case and submit it as a pull request (PR) at [https://github.com/nih-cfde/usecases](https://github.com/nih-cfde/usecases). Please follow the [Use Case Style Guide](#usecasestyle) below.
 
 ### PR format
 If you are submitting a pull request:
+
 - Please create one pull request per use case so admin can check the complete change
+
 - Request review from @Acharbonneau and @marisalim
+
 - Please allow up to one week for admin to review your request
 
 ### Use Case approval process
-  - The Use Case committee will mark proposed use cases as `in progress`, `approved`, and `done`, as appropriate.
-  - If the Use Case has been approved, a &#x2705; will be added next to the Use Case tab title, as well as its corresponding Requirements tab titles.
+- The Use Case committee will mark proposed use cases as `in progress`, `approved`, and `done`, as appropriate.
+  
+- If the Use Case has been approved, a &#x2705; will be added next to the Use Case tab title, as well as its corresponding Requirements tab titles.
 
 If you have any questions about contributing, please [open an issue](https://github.com/nih-cfde/usecases/issues/new) and we will lend a hand ASAP.
 
@@ -42,30 +47,34 @@ Thank you for being here and for being a part of the CFDE project.
 
 ### Use Case Structure
 - All Use Cases must have:
-  - a **Persona**
-  - an **Objective**
-  - a **Summary** of the Objective
-  - specific **User Tasks**
-  - technical infrastructure **Requirements** for each User Task
+    - a **Persona**
+    - an **Objective**
+    - a **Summary** of the Objective
+    - specific **User Tasks**
+    - technical infrastructure **Requirements** for each User Task
 - See [glossary](./glossary.md) for definitions
 - Each persona, objective, user task, and requirement needs its own description page that will be linked to in the corresponding use case page(s) (some common user tasks and requirements may be repeated across use cases).
 
-
 ### General File Format
 
-  **TO DO: make template file for use case pg?**
-
 - **File format**: all files should be written in Markdown
-  - For help with Markdown syntax, see this [basic syntax guide](https://www.markdownguide.org/basic-syntax/)
-  - To add links to other pages:
+
+    - For help with Markdown syntax, see this [basic syntax guide](https://www.markdownguide.org/basic-syntax/)
+  
+    - To add links to other pages:
+  
     ```
     [<text to click on>](<link to file>)
     ```
+    
     This is an example for a link to the Personas description page for 'Clinical Researcher':
+    
     ```
     [Clinical Researcher](../personas/clinical-researcher.md)
     ```
+    
 - **Site index**: automatically created by yaml headers in each file (only the title is visible on the rendered website). The yaml header must be formatted as follows:
+
   ```
   ---
   layout: default
@@ -76,7 +85,9 @@ Thank you for being here and for being a part of the CFDE project.
   has_children: false
   ---
   ```
+  
   This is an example for the 'UC0001' Use Case:
+  
   ```
   ---
   layout: default
@@ -87,7 +98,9 @@ Thank you for being here and for being a part of the CFDE project.
   has_children: false
   ---
   ```
+  
   The `parent` value depends on the Use Case file type:
+  
   `parent:` value | Type
   --- | ---
   `Use Cases` | for the main Use Case file
@@ -98,65 +111,65 @@ Thank you for being here and for being a part of the CFDE project.
   
 - **File names**: should be lower case, have hyphens, and match the heading. Use Case (`ucXXXX`), User Task (`tXXXX`), and Requirement (`rXXXXX`) files should include a file code numbered in order of appearance in this Use Case Library website.
 
-    File type | Example
-    --- | ---
-    use case | uc0001-researcher-browse-and-filter.md
-    persona | clinical-researcher.md
-    objective | create-data-release.md
-    user task | t0001-access-cfde-interface.md
-    requirement | r00001-the-interface-will-support-gui-web-access-to-end-users.md
+   File type | Example
+   --- | ---
+   use case | uc0001-researcher-browse-and-filter.md
+   persona | clinical-researcher.md
+   objective | create-data-release.md
+   user task | t0001-access-cfde-interface.md
+   requirement | r00001-the-interface-will-support-gui-web-access-to-end-users.md
 
 #### `Use Case` files
 - Required sections:
-  - yaml index header
-  - Page header: title, date completed (`<month> <year>`), persona, objective
-  ```
-  <Title>
-  Completed:
-  Persona:
-  Objective:
-  ```
-  - `Summary`: a short summary of the use case
-  - `User Tasks`: a bullet point list of the tasks required for the use case, including links to each task page. Tasks are numbered by `TXXXX`.
-  - `Requirements`: a bullet point list of the requirements for each task, including links to each requirement page. Requirements are numbered by `RXXXXX`.
+    - yaml index header
+    - Page header: title, date completed (`<month> <year>`), persona, objective
+    ```
+    <Title>
+    Completed:
+    Persona:
+    Objective:
+    ```
+    - `Summary`: a short summary of the use case
+    - `User Tasks`: a bullet point list of the tasks required for the use case, including links to each task page. Tasks are numbered by `TXXXX`.
+    - `Requirements`: a bullet point list of the requirements for each task, including links to each requirement page. Requirements are numbered by `RXXXXX`.
 - The persona, objective, user tasks, and requirements need to be linked to their corresponding description page (detailed in the following sections)
 
 #### `Persona` files
 - Required sections:
-  - yaml index header
-  - Short description of their biological/computational experience and relation to any of the other Personas in the Use Cases Repository
-  - Persona title (same as yaml index title)
-  - Short description of the type of work they do, slightly more detailed than the first description
-  - A section listing assumptions about the persona's credentials e.g., access to the CFDE, formatted as follows:
-  ```
-  Assumptions
-        Users with this persona:
-  ```
+    - yaml index header
+    - Short description of their biological/computational experience and relation to any of the other Personas in the Use Cases Repository
+    - Persona title (same as yaml index title)
+    - Short description of the type of work they do, slightly more detailed than the first description
+    - A section listing assumptions about the persona's credentials e.g., access to the CFDE, formatted as follows:
+    
+    ```
+    Assumptions
+          Users with this persona:
+    ```
 
 #### `Objective` files
 - Required sections:
-  - yaml index header
-  - `<name of the task>:`: brief ~1 sentence description of the task
+    - yaml index header
+    - `<name of the task>:`: brief ~1 sentence description of the task
 
 #### `User task` files
 - Required sections:
-  - yaml index header
-  - `Appears in Use Cases:`: bullet point list of the use case(s) that the task appears in, with page link to the use case page(s)
-
-**TO DO: will this page eventually include a description of the task?**
+    - yaml index header
+    - `Appears in Use Cases:`: bullet point list of the use case(s) that the task appears in, with page link to the use case page(s)
 
 #### `Requirement` files
 - Required sections:
-  - yaml index header
-  - Requirement title (same as yaml index title)
-  - An `Appears in` section with two sub-sections:
-  ```
-  Appears in:
-      User Tasks
+    - yaml index header
+    - Requirement title (same as yaml index title)
+    - An `Appears in` section with two sub-sections:
+  
+    ```
+    Appears in:
+        User Tasks
 
-      Use Cases
-  ```
-    - Under `User Tasks`: bullet point list of the task(s) that the requirement appears in, with page link to the user task page
-    - Under `Use Cases`: bullet point list of the use case(s) that the requirement appears in, with page link to the use case page(s)
+        Use Cases
+    ```
+  
+      - Under `User Tasks`: bullet point list of the task(s) that the requirement appears in, with page link to the user task page
+      - Under `Use Cases`: bullet point list of the use case(s) that the requirement appears in, with page link to the use case page(s)
 
-**TO DO: will this page eventually include a description of the requirement?**

--- a/docs/personas/cfde-clinical-researcher.md
+++ b/docs/personas/cfde-clinical-researcher.md
@@ -10,8 +10,6 @@ This end user understands biology, and is comfortable with point and click inter
 but does not use the command line or know any programming languages. They have
 associated a credential with the CFDE.
 
-### Clinical Researcher
-
 They will primarily interact with the data using a web browser or spreadsheets,
 and will expect that the data is in a human readable format. They will rarely
 work in a coding interface, however they may want to turn data they collected in

--- a/docs/personas/clinical-researcher.md
+++ b/docs/personas/clinical-researcher.md
@@ -10,8 +10,6 @@ This end user understands biology, and is comfortable with point and click inter
 but does not use the command line or know any programming languages. They have
 no ongoing association with the CFDE.
 
-### Clinical Researcher
-
 They will primarily interact with the data using a web browser or spreadsheets,
 and will expect that the data is in a human readable format. They will rarely
 work in a coding interface, however they may want to turn data they collected in

--- a/docs/personas/data-administrator.md
+++ b/docs/personas/data-administrator.md
@@ -8,8 +8,6 @@ has_children: false
 
 This user is a technical administrator of raw data, pipelines, portal, tools and/or processed data. They are supervised by a Data Custodian.
 
-### Data Administrator
-
 This user is charged with making sure their DCC's data is available, widely used, and used appropriately. 
 They have a deep knowledge of their DCC's dataset and the semantic meaning of each data component.
 Their computational knowledge ranges from intermediate to professional bioinformatician.

--- a/docs/personas/data-custodian.md
+++ b/docs/personas/data-custodian.md
@@ -8,8 +8,6 @@ has_children: false
 
 This user owns or is a custodian of raw data, pipelines, portal, tools and/or processed data. They are usually a DCC PI.
 
-### Data Custodian
-
 This user has a vested interest in making sure their data is available, widely used, and used appropriately. They are concerned both that their data is being used within the confines of its use policy, and also that users are making sound statistical and biological inferences with it. They have a deep knowledge of their dataset and how it can and can’t be used to answer questions; however, their computational knowledge may range from novice to professional bioinformatician.
 
 ### Assumptions

--- a/docs/personas/data-scientist.md
+++ b/docs/personas/data-scientist.md
@@ -8,8 +8,6 @@ has_children: false
 
 This end user understands computation, and is comfortable with the command line interface (CLI) and at least one other programming language, however they are not experts in biology.
 
-### Data Scientist
-
 They will primarily interact with the data using an API, and will expect that the data is in a form that can be used by workflow languages. They will rarely work in a point and click interface here, however they may be receive lists of data files to analyze which their less computational colleagues created using the GUI.
 
 ### Assumptions

--- a/docs/personas/program-officer.md
+++ b/docs/personas/program-officer.md
@@ -8,8 +8,6 @@ has_children: false
 
 This user is an NIH administrator for a Common Fund Program.
 
-### Program Officer
-
 This user is interested in ensuring that their programs are meeting NIH goals and
 are useful to the scientific community. While they have many of the same interests
 as a data-custodian, they will typically be checking in with less frequency, and

--- a/docs/template_files/objective-template.md
+++ b/docs/template_files/objective-template.md
@@ -6,4 +6,4 @@ parent: Objectives
 has_children: false
 ---
 
-ADD objective title: ADD brief objective description
+ADD brief objective description

--- a/docs/template_files/objective-template.md
+++ b/docs/template_files/objective-template.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: ADD objective title
+nav_order: ADD page number
+parent: Objectives
+has_children: false
+---
+
+ADD objective title: ADD brief objective description

--- a/docs/template_files/persona-template.md
+++ b/docs/template_files/persona-template.md
@@ -1,16 +1,16 @@
 ---
 layout: default
 title: ADD persona name
-nav_order: ADD page numer
+nav_order: ADD page number
 parent: Personas
 has_children: false
 ---
 
-ADD Short description of their biological/computational experience and relation to any of the other Personas in the Use Cases Repository
+ADD Short description of their biological/computational experience level and relation to any of the other Personas in the Use Cases Repository
 
 ### ADD persona name
 
-ADD Short description of the type of work they do, slightly more detailed than the first description
+ADD Short description of their role and responsibilities, slightly more detailed than the first description
 
 ### Assumptions
 

--- a/docs/template_files/persona-template.md
+++ b/docs/template_files/persona-template.md
@@ -6,11 +6,7 @@ parent: Personas
 has_children: false
 ---
 
-ADD Short description of their biological/computational experience level and relation to any of the other Personas in the Use Cases Repository
-
-### ADD persona name
-
-ADD Short description of their role and responsibilities, slightly more detailed than the first description
+ADD Short description of their biological/computational experience level, their role and responsibilities, and relation to any of the other Personas in the Use Cases Repository
 
 ### Assumptions
 

--- a/docs/template_files/persona-template.md
+++ b/docs/template_files/persona-template.md
@@ -1,0 +1,19 @@
+---
+layout: default
+title: ADD persona name
+nav_order: ADD page numer
+parent: Personas
+has_children: false
+---
+
+ADD Short description of their biological/computational experience and relation to any of the other Personas in the Use Cases Repository
+
+### ADD persona name
+
+ADD Short description of the type of work they do, slightly more detailed than the first description
+
+### Assumptions
+
+Users with this persona:
+
+-   ADD assumptions

--- a/docs/template_files/requirement-template.md
+++ b/docs/template_files/requirement-template.md
@@ -1,0 +1,20 @@
+---
+layout: default
+title: ADD requirement title
+nav_order: ADD page number
+parent: Requirements
+has_children: false
+---
+
+# ADD requirement title
+
+## Appears in:
+
+### User Tasks
+
+-   [ADD task name](../user-tasks/ADD task file name)
+
+
+### Use Cases
+
+-   [ADD use case name](../use-cases/ADD use case file name)

--- a/docs/template_files/use-case-template.md
+++ b/docs/template_files/use-case-template.md
@@ -1,0 +1,32 @@
+---
+layout: default
+title: "ADD Use Case title here"
+nav_order: ADD page number
+parent: Use Cases
+completed: ADD completion month and completion year (e.g., July 2020)
+has_children: false
+---
+
+# Use Case ADD Use Case title here
+
+**Completed:** ADD completion month and completion year
+
+**Persona:** [ADD persona name](../personas/ADD persona file name)
+
+**Objective:** [ADD objective name](../objectives/ADD objective file name)
+
+### Summary
+
+ADD Use Case summary
+
+### User Tasks
+
+-   [ADD task name](../user-tasks/ADD task file name)
+
+### Requirements
+
+#### ADD task name (this must match the tasks listed above)
+
+-   [ADD requirement name](../requirements/ADD requirement file name)
+
+

--- a/docs/template_files/user-task-template.md
+++ b/docs/template_files/user-task-template.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: ADD user task title
+nav_order: ADD page number
+parent: User Tasks
+has_children: false
+---
+
+## Appears in Use Cases:
+
+-   [ADD user task](../use-cases/ADD user task file)


### PR DESCRIPTION
@marisalim 

This is not remotely ready to merge, but I wanted to give you more of a framework for what I was asking for. The people we are expecting to contribute to the UCL are not just our team, and not necessarily even just from the CFDE. It needs *everything* explained. What files they need, in what format, naming conventions, how we want PRs. I've left a lot of ellipses for you to fill in. 

What might help for you to get an idea what I'm looking for, is for you to actually just write a small use case, and see what things you have to go dig around to see how they should be. We don't want to make our users have to go dig around, we want everything they need to know in one place. 


Preview: https://cfde-usecases.readthedocs-hosted.com/en/styleguide/about/contributing/