### PR TITLE
Mkdocs syntax updates

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -1,4 +1,4 @@
-arrange:
+nav:
   - index.md
   - about
   - use-cases

--- a/docs/about/.pages
+++ b/docs/about/.pages
@@ -1,3 +1,3 @@
-arrange:
+nav:
   - contributing.md
   - glossary.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,8 @@ theme:
   palette:
     primary: white
   features:
-    - tabs
+    - navigation.tabs
+    - navigation.instant
   logo: images/CFDE-logo.png
   custom_dir: docs/templates
 


### PR DESCRIPTION
Addressing updates to Mkdocs syntax with latest version; this fixes rendering issues for the websites

Change syntax under "features" in the mkdocs.yml file to:
```
features:
    - navigation.tabs
    - navigation.instant
```

 change `arrange` on .pages files to `nav`

preview: https://cfde-usecases--56.com.readthedocs.build/en/56/?next=https%3A%2F%2Fcfde-usecases--56.com.readthedocs.build%2Fen%2F56%2F&ticket=ST-1601919528-exfoyRK0NmBoClpdTJRcuGzQ3t6TYMUe

review: verify navigation tabs render, page org still functioning
